### PR TITLE
Task #18: bugfix on metadata links

### DIFF
--- a/rndt/models.py
+++ b/rndt/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.db.models import signals
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from geonode.base.models import resourcebase_post_save
+from geonode.base.models import Link, resourcebase_post_save
 from geonode.groups.models import GroupProfile
 from geonode.layers.models import Layer, ResourceBase
 
@@ -92,6 +92,8 @@ def _group_post_save(sender, instance, raw, **kwargs):
             resource.save()
 
         r_updated = ",".join([str(r.id) for r in resources])
+        l = Link.objects.filter(link_type='metadata').filter(resource__id=resource.id)
+        l.delete()
         print(f"Following resources id has been updated : {r_updated}")
     # updating Links
 

--- a/rndt/uuidhandler.py
+++ b/rndt/uuidhandler.py
@@ -1,6 +1,8 @@
 import logging
-import uuid
 import re
+import uuid
+
+from geonode.base.models import Link
 
 
 class UUIDHandler:
@@ -30,7 +32,7 @@ class UUIDHandler:
                 )
         else:
             newuuid = f"{layer_ipa}:{self.instance.uuid}"
-
+        self.delete_old_metadata_links()
         return newuuid[:36]
 
     def get_layer_ipa(self):
@@ -64,3 +66,7 @@ class UUIDHandler:
         pattern = re.compile(":\W*(\w+)\W*$")
         match = re.findall(pattern, instance_uuid)
         return match[0] if match else False
+
+    def delete_old_metadata_links(self):
+        l = Link.objects.filter(link_type='metadata').filter(resource__id=self.instance.id)
+        l.delete()


### PR DESCRIPTION
Bugfix in order to let the new `UUIDHandler` to delete the olds metadata links generated with the previous uuid