### PR TITLE
Task #69: fix typo for access constraints

### DIFF
--- a/rndt/layers/views.py
+++ b/rndt/layers/views.py
@@ -66,7 +66,7 @@ def layer_metadata(
             #  if the object exists and the constraing_other is changed
             #  the value will be updated
             available = available.first()
-            available.constraints_other = keyword.about if keyword else None,
+            available.constraints_other = keyword.about if keyword else None
             available.resolution = items["resolution"]
             available.accuracy = items["accuracy"]
             #  save the new value in the DB


### PR DESCRIPTION
There was a typo in the access_constraints definition where were saved as tuple instead of string.

In the xml was rendered in this way:
> XML -> <ns4:Anchor ns5:href="('http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations',)">None</ns4:Anchor>
Value in the DB -> `('http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations',)`

Now, is rendered in this way:

> XML -> <ns4:Anchor ns5:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">no limitations to public access</ns4:Anchor>
Value in the db -> `http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations`