### PR TITLE
Upgrade to compatibility with django3

### DIFF
--- a/rndt/templates/search/search_scripts.html
+++ b/rndt/templates/search/search_scripts.html
@@ -1,5 +1,5 @@
 {% extends "search/search_scripts.html" %}
-{% load static from staticfiles %}
+{% load static %}
 {% block search_scripts_endpoints %}
   CATEGORIES_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='categories' %}';
   GROUP_CATEGORIES_ENDPOINT = '{% url 'api_dispatch_list' api_name='api' resource_name='groupcategory' %}';


### PR DESCRIPTION
Relates to  https://github.com/GeoNode/geonode/issues/7366 let rndt app be compatible with Django3