### PR TITLE
#104 Error parsing metadata

### DIFF
--- a/rndt/layers/metadata.py
+++ b/rndt/layers/metadata.py
@@ -20,11 +20,8 @@ def rndt_parser(xml, uuid="", vals={}, regions=[], keywords=[], custom={}):
         raise GeoNodeException(f"Uploaded XML document is not XML: {str(err)}")
 
     # check if document is an accepted XML metadata format
-    tagname = get_tagname(exml)
-
-    if tagname == "GetRecordByIdResponse":  # strip CSW element
-        exml = exml.getchildren()[0]
-        tagname = get_tagname(exml)
+    if get_tagname(exml) == "GetRecordByIdResponse":  # strip CSW element
+        exml = list(exml)[0]
 
     rndt_parser = RNDTMetadataParser(exml)
 


### PR DESCRIPTION
#104 

https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren
> getchildren()
> Deprecated since version 3.2, will be removed in version 3.9: Use list(elem) or iteration.