### PR TITLE
[Fixes #107] Tkeywords in exported XML are not localized

### DIFF
--- a/rndt/templates/xml/template-rndt.xml
+++ b/rndt/templates/xml/template-rndt.xml
@@ -364,7 +364,7 @@
                {% if keyword.thesaurus.id == thesaurus_id %}
                <gmd:keyword>
                   <gmx:Anchor 
-                     xlink:href="{{keyword.about}}">{{keyword.alt_label}}</gmx:Anchor>
+                     xlink:href="{{keyword.about}}">{{keyword|rndt_get_localized_tkeyword}}</gmx:Anchor>
                </gmd:keyword>
                {% endif %}
                {% endfor %}

--- a/rndt/templatetags/metadata_tags.py
+++ b/rndt/templatetags/metadata_tags.py
@@ -1,6 +1,6 @@
 from django import template
 from django.core.validators import URLValidator
-from geonode.base.models import Thesaurus, ThesaurusKeyword
+from geonode.base.models import Thesaurus, ThesaurusKeyword, ThesaurusKeywordLabel
 from rndt.models import LayerRNDT
 
 register = template.Library()
@@ -11,6 +11,16 @@ def get_thesaurus_about(thesaurus_id):
     t = Thesaurus.objects.filter(id=thesaurus_id)
     if t.exists():
         return Thesaurus.objects.get(id=thesaurus_id).about
+
+
+@register.filter
+def rndt_get_localized_tkeyword(tkeyword: ThesaurusKeyword):
+    for lang in ('it', 'en'):
+        t = ThesaurusKeywordLabel.objects.filter(keyword=tkeyword, lang=lang)
+        if t.exists():
+            return t.first().label
+
+    return tkeyword.alt_label
 
 
 @register.filter


### PR DESCRIPTION
Force IT as preferred lang sinche RNDT is italian, thsn EN bc it should exist as per Thesauri specificaitons.

Filter is prepended with `rndt_` in order not to create conflict should this fileter be ported into GeoNode.